### PR TITLE
Add scriptFilePath to Globals in RayCastingScripts.cs and catch exceptions during scene script execution

### DIFF
--- a/common/RayCastingScripts.cs
+++ b/common/RayCastingScripts.cs
@@ -163,6 +163,11 @@ namespace Rendering
       /// Parameter map for passing values in/out of the script.
       /// </summary>
       public ScriptContext context;
+
+      /// <summary>
+      /// Path to Scene file.
+      /// </summary>
+      public string scriptFilePath;
     }
 
     protected static int count = 0;
@@ -357,7 +362,8 @@ namespace Rendering
             sceneName = name,
             scene     = sc,
             param     = par,
-            context   = ctx
+            context   = ctx,
+            scriptFilePath = scriptFileName
           };
 
           bool ok = true;
@@ -373,6 +379,11 @@ namespace Rendering
           catch (CompilationErrorException e)
           {
             MessageBox.Show($"Error compiling scene script: {e.Message}, using default scene", "CSscript Error");
+            ok = false;
+          }
+          catch (AggregateException e)
+          {
+            MessageBox.Show($"Error running scene script: {e.InnerException.Message}, using default scene", "CSscript Error");
             ok = false;
           }
 


### PR DESCRIPTION
Cesta k souboru se scénou se nám hodí například pro animovanou kameru, aby bylo možné hledat soubor s keyframes relativně vůči scéně (např. mít ho ve stejné složce) a ne relativně vůči tomu, odkud je spuštěný program (`062animation-script\bin\Debug\...`).

Příklad uvnitř skriptu scény – keyframes.yaml je ve stejné složce:
```
string keyframes_file = Path.Combine(Path.GetDirectoryName(scriptFileName), "keyframes.yaml");
```

Přijde mi, že tato změna moc zasahuje do kódu projektu a nedává smysl dělat ji jako extension, proto vytvářím pull request. 